### PR TITLE
BASE_PATHの設定を変更。

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -8,7 +8,7 @@ const config = {
 		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
 		adapter: adapter(),
 		paths: {
-			base: process.argv.includes('dev') ? '' : process.env.BASE_PATH
+			base: process.argv.includes('dev') ? '' : '/'  //process.env.BASE_PATH
 		}
 	}
 };


### PR DESCRIPTION
リポジトリの名前`1your-username.github.io`でない場合は、

`process.env.BASE_PATH`に戻した上でGitHubにて`BASE_PATH`を環境変数に設定する必要がある。

参考URL
https://kit.svelte.jp/docs/adapter-static#github-pages
